### PR TITLE
Update slimselect.vue

### DIFF
--- a/src/vue/slimselect.vue
+++ b/src/vue/slimselect.vue
@@ -57,7 +57,7 @@ export default defineComponent({
     // Wrap config.events.afterChange to run value update
     const ogAfterChange = config.events.afterChange
     config.events.afterChange = (newVal: Option[]) => {
-      const value = this.multiple ? newVal.map((option) => option.value) : newVal[0].value
+      const value = this.multiple ? newVal.map((option) => option.value) : newVal.length > 0 ? newVal[0].value : '';
 
       // Check if value is different from modelValue
       if (this.value !== value) {


### PR DESCRIPTION
Bugfix on afterChange event

When slimselect component is not multiple and current value is deselect, and error is throw : `TypeError: newVal[0] is undefined`

This is cause by `newVal` function parameter which is an empty array in this case, so newVal[0] is not an option but undefined